### PR TITLE
Add nose dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 cython
+nose


### PR DESCRIPTION
Given its reference in readme, we should list it in requirements, otherwise readme setup fails